### PR TITLE
facebook login now routes to homepage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,8 @@ class ApplicationController < ActionController::Base
     # For additional fields in app/views/devise/registrations/new.html.erb
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :location])
   end
+
+  def after_sign_in_path_for(resource)
+    root_path
+  end
 end


### PR DESCRIPTION
The Facebook login now routes correctly instead of defaulting to the shoe index page as was previously happening.